### PR TITLE
chore: remove bot notifications

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
This removes vercel bot notifications for every deployment as per [vercel's docs](https://vercel.com/guides/how-to-prevent-vercel-github-comments#preventing-comments).