### PR TITLE
refactor: remove "Integrations" nesting

### DIFF
--- a/docs/apps/05-url-schemes.mdx
+++ b/docs/apps/05-url-schemes.mdx
@@ -1,6 +1,6 @@
 ---
 id: "url-schemes"
-sidebar_position: 1
+sidebar_position: 5
 title: "URL Schemes"
 ---
 

--- a/docs/apps/integrations/_category_.json
+++ b/docs/apps/integrations/_category_.json
@@ -1,5 +1,0 @@
-{
-  "collapsed": false,
-  "label": "Integrations",
-  "position": 5
-}


### PR DESCRIPTION
Ref https://github.com/sablier-labs/v2-docs/pull/89#issuecomment-1679441694.

We would ideally nest the "Stream Page", "Create Stream Autofill", and the "Search Streams" in child pages under "URL Schemes", but I'll let you decide @razgraf. All I care is removing the "Integrations" section, which we don't need.