### PR TITLE
fixes broken proxy architecture links

### DIFF
--- a/docs/contracts/v2/guides/create-stream/01-lockup-linear.mdx
+++ b/docs/contracts/v2/guides/create-stream/01-lockup-linear.mdx
@@ -24,7 +24,7 @@ This guide assumes that you have already gone through the [Protocol Concepts](/c
 
 This guide interacts with the Core contracts directly. To get access to the whole gamut of Sablier features, we
 recommend creating streams via the Periphery contracts instead. See the
-[Proxy Architecture](/contracts/v2/guides/proxy-architecture) section.
+[Proxy Architecture](/contracts/v2/guides/proxy-architecture/overview) section.
 
 :::
 

--- a/docs/contracts/v2/guides/create-stream/02-lockup-dynamic.mdx
+++ b/docs/contracts/v2/guides/create-stream/02-lockup-dynamic.mdx
@@ -24,7 +24,7 @@ This guide assumes that you have already gone through the [Protocol Concepts](/c
 
 This guide interacts with the Core contracts directly. To get access to the whole gamut of Sablier features, we
 recommend creating streams via the Periphery contracts instead. See the
-[Proxy Architecture](/contracts/v2/guides/proxy-architecture) section.
+[Proxy Architecture](/contracts/v2/guides/proxy-architecture/overview) section.
 
 :::
 

--- a/docs/contracts/v2/guides/proxy-architecture/03-batch-stream.mdx
+++ b/docs/contracts/v2/guides/proxy-architecture/03-batch-stream.mdx
@@ -18,7 +18,7 @@ Batch create means creating multiple streams within a transaction, which is done
 
 :::note
 
-This guide assumes that you have already read the [Proxy Architecture](/contracts/v2/guides/proxy-architecture)
+This guide assumes that you have already read the [Proxy Architecture](/contracts/v2/guides/proxy-architecture/overview)
 overview.
 
 :::


### PR DESCRIPTION
- there are links to https://docs.sablier.com/contracts/v2/guides/proxy-architecture in the docs which is broken this pr fixes that