### PR TITLE
fix(concepts): supported chains count

### DIFF
--- a/docs/concepts/07-chains.mdx
+++ b/docs/concepts/07-chains.mdx
@@ -7,11 +7,11 @@ sidebar_position: 7
 import Chains from "@site/src/components/organisms/Chains";
 import { Links } from "@site/src/constants";
 import { keys } from "lodash";
-import { mainnets, testnets } from "sablier";
+import { sablier } from "sablier";
 
 <>
 
-The Sablier Protocol is deployed on {keys(mainnets).length} mainnets and {keys(testnets).length} testnet EVM chains, although not all of these are supported by the
+The Sablier Protocol is deployed on {sablier.chains.getMainnets().length} mainnets and {sablier.chains.getTestnets().length} testnet EVM chains, although not all of these are supported by the
 [Sablier Interface](https://app.sablier.com/).
 
 </>


### PR DESCRIPTION
As I was working on the solana docs, I noticed there was an issue with the number of supported chains


<img width="888" height="191" alt="image" src="https://github.com/user-attachments/assets/98d1e24d-35e3-47fe-942f-bc3ef7b1f5d7" />
