### PR TITLE
Clarify merkle api integration

### DIFF
--- a/docs/api/airdrops/merkle-api/01-overview.mdx
+++ b/docs/api/airdrops/merkle-api/01-overview.mdx
@@ -24,6 +24,14 @@ We've built a Rust backend service that provides REST API access to Merkle tree 
 
 ## Integrations
 
-Integrate this API using our official endpoints or fork the repository to run your own instance. We actively improve and optimize this service, so submit suggestions or issues directly on GitHub.
+Integrate this API by forking the repository to run your own instance. We actively improve and optimize this service, so submit suggestions or issues directly on GitHub.
+
+:::tip
+If you want to integrate the eligibility/claim functionality in your, you have the following options:
+
+1. Self Host the above api
+2. Reach out for a more powerful backend we can host for you
+3. Reach out for a custom script to pre-generate proofs and save them wherever it suits you
+   :::
 
 <LinkPreviewMerkleAPI />

--- a/docs/api/airdrops/merkle-api/02-functionality.mdx
+++ b/docs/api/airdrops/merkle-api/02-functionality.mdx
@@ -104,12 +104,6 @@ For implementation details, check out the source code:
 
 Call this route to check if a recipient is eligible to claim a stream from the Merkle airdrop campaign.
 
-:::info
-
-This endpoint uses authentication. Please reach out if you need to use our deployed endpoints in your application.
-
-:::
-
 ### Prerequisites
 
 To check eligibility for an address, you'll need:


### PR DESCRIPTION
This pr aims to remove the reference for the token need in order to access the merkle api and provide some other options for the parties interested in integrating the eligibility/claim functionality.