### PR TITLE
fix: autogen script

### DIFF
--- a/cli/autogen-reference.sh
+++ b/cli/autogen-reference.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 root=$(pwd)
 
 # Install monorepo dependencies (needed for forge doc to compile)
-bun install --ignore-scripts --cwd "$root/repos/evm-monorepo"
+bun install --cwd "$root/repos/evm-monorepo"
 
 # Define the contracts directories
 airdrops=docs/reference/airdrops/contracts


### PR DESCRIPTION
### Problems && Fixes

- `evm-monorepo` was pointing to [this commit](https://github.com/sablier-labs/evm-monorepo/commit/003a71932c0e26e767a02c21205a077469406ac8):
     - it was incorrectly installing all dependencies recursively with no stop; fixed in [this commit](https://github.com/sablier-labs/evm-monorepo/commit/ffd6412b29b69dbe4019ae311ca3695116366e45)
- `bun install` was using the `--ignore-scripts` flag, which we actually need in order to install deps across all protocols